### PR TITLE
feat(overall): Add Overall Mode

### DIFF
--- a/src/main/java/com/combatlogger/CombatLoggerConfig.java
+++ b/src/main/java/com/combatlogger/CombatLoggerConfig.java
@@ -62,6 +62,19 @@ public interface CombatLoggerConfig extends Config
 		return new Color(139, 15, 16);
 	}
 
+	/**
+	 * Configuration item for enabling the "Overall" fight mode.
+	 * When enabled, all combat data is logged into a single, continuous fight session
+	 * instead of creating a new session for each encounter.
+	 */
+	@ConfigItem(
+			keyName = "overallMode",
+			name = "Enable Overall Mode",
+			description = "Logs all damage into a single 'Overall' fight until disabled.",
+			position = 3
+	)
+	default boolean overallMode() { return false; }
+
 	/* Overlay Settings
 	 * POSITIONS: 26-49
 	 * */

--- a/src/main/java/com/combatlogger/panel/CombatLoggerPanel.java
+++ b/src/main/java/com/combatlogger/panel/CombatLoggerPanel.java
@@ -92,14 +92,14 @@ public class CombatLoggerPanel extends PluginPanel
 		cardLayout = new CardLayout();
 		damageMeterPanel = new JPanel(cardLayout);
 
-		updateFightsComboBox(fightManager.getFights());
+		updateFightsComboBox(config,fightManager.getFights());
 
 		JButton clearFightsButton = createButton(CLOSE_ICON, "Clear all fights", () ->
 		{
 			if (isConfirmed("Are you sure you want to clear all fights?", "Clear all fights"))
 			{
 				fightManager.clearFights();
-				updateFightsComboBox(fightManager.getFights());
+				updateFightsComboBox(config,fightManager.getFights());
 				updateOverviewPanel(new ArrayList<>());
 				showOverviewPanel();
 			}
@@ -165,11 +165,15 @@ public class CombatLoggerPanel extends PluginPanel
 		currentFightLengthLabel.setText(fightLength);
 	}
 
-	public void updateFightsComboBox(BoundedQueue<Fight> fights)
+	public void updateFightsComboBox(CombatLoggerConfig config, BoundedQueue<Fight> fights)
 	{
 		List<Fight> updatedFights = new ArrayList<>();
 		// Reverse order so the newest fights are first
 		fights.descendingIterator().forEachRemaining(updatedFights::add);
+
+		if (config.overallMode() && fightManager.getOverallFight() != null) {
+			updatedFights.add(0, fightManager.getOverallFight()); // Add overall fight to the top
+		}
 
 		List<Fight> existingFights = new ArrayList<>();
 		for (int i = 0; i < fightsComboBox.getItemCount(); i++)
@@ -213,9 +217,15 @@ public class CombatLoggerPanel extends PluginPanel
 	/**
 	 * Update the panel with the latest data
 	 */
-	public void updatePanel()
+	public void updatePanel(CombatLoggerConfig config)
 	{
-		selectedFight = fightManager.getSelectedFight();
+		// If in overall mode, force the selected fight to be the overall fight
+		if (config.overallMode() && fightManager.getOverallFight() != null) {
+			selectedFight = fightManager.getOverallFight();
+		} else {
+			selectedFight = fightManager.getSelectedFight();
+		}
+
 		if (selectedFight != null)
 		{
 			List<PlayerStats> playerStats = fightManager.getPlayerDamageForFight(selectedFight);
@@ -227,7 +237,7 @@ public class CombatLoggerPanel extends PluginPanel
 			updateCurrentFightLength("00:00");
 		}
 
-		updateFightsComboBox(fightManager.getFights());
+		updateFightsComboBox(config,fightManager.getFights());
 	}
 }
 


### PR DESCRIPTION
This commit introduces a new "Overall" mode to the Combat Logger. When enabled, all combat data is logged into a single, continuous fight session, which persists until the mode is disabled or the client is closed. This provides users with a way to track their total damage over an entire play session without creating separate entries for each encounter.

Key Changes:

Overall Mode:

Added an "Enable Overall Mode" toggle in the plugin configuration.

Implemented logic in FightManager to start, stop, and manage a single overallFight object.

Modified addDamage and addTicks to route all data to the overallFight when the mode is active, preventing the creation of new fight sessions.

Added startUp and shutDown methods to CombatLoggerPlugin to correctly initialize and terminate the "Overall" mode when RuneLite starts or closes with the setting enabled.